### PR TITLE
More customizable LETimeIntervalPicker

### DIFF
--- a/Example/LETimeIntervalPicker/ViewController.swift
+++ b/Example/LETimeIntervalPicker/ViewController.swift
@@ -20,8 +20,8 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.picker.componentOne = Components.Year
-        self.picker.componentTwo = .Month
-        self.picker.componentThree = .Week
+        self.picker.componentTwo = .None
+        self.picker.componentThree = .None
         self.picker.setup()
         formatter.unitsStyle = .Abbreviated
     }

--- a/Example/LETimeIntervalPicker/ViewController.swift
+++ b/Example/LETimeIntervalPicker/ViewController.swift
@@ -19,9 +19,9 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.picker.componentOne = .Year
+        self.picker.componentOne = .Week
         self.picker.componentTwo = .Second
-        self.picker.componentThree = .None
+        self.picker.componentThree = .Minute
         self.picker.setup()
         formatter.unitsStyle = .Abbreviated
     }

--- a/Example/LETimeIntervalPicker/ViewController.swift
+++ b/Example/LETimeIntervalPicker/ViewController.swift
@@ -19,10 +19,6 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.picker.componentOne = .None
-        self.picker.componentTwo = .Year
-        self.picker.componentThree = .Hour
-        self.picker.setup()
         formatter.unitsStyle = .Abbreviated
     }
     

--- a/Example/LETimeIntervalPicker/ViewController.swift
+++ b/Example/LETimeIntervalPicker/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         self.picker.componentOne = .Week
         self.picker.componentTwo = .Second
-        self.picker.componentThree = .Minute
+        self.picker.componentThree = .Day
         self.picker.setup()
         formatter.unitsStyle = .Abbreviated
     }
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
     @IBAction func updateLabel(sender: LETimeIntervalPicker) {
         label.text = formatter.stringFromTimeInterval(sender.timeInterval)
         
-//        label.text = "\(sender.timeIntervalAsHoursMinutesSeconds.hours) \(sender.timeIntervalAsHoursMinutesSeconds.minutes) \(sender.timeIntervalAsHoursMinutesSeconds.seconds)"
+//        label.text = "\(sender.timeIntervalAsComponentTypes.valueOne) \(sender.timeIntervalAsComponentTypes.valueTwo) \(sender.timeIntervalAsComponentTypes.valueThree)"
     }
     
     @IBAction func setRandomTimeInterval() {

--- a/Example/LETimeIntervalPicker/ViewController.swift
+++ b/Example/LETimeIntervalPicker/ViewController.swift
@@ -19,23 +19,23 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.picker.componentOne = .Week
-        self.picker.componentTwo = .Second
-        self.picker.componentThree = .Day
+        self.picker.componentOne = .None
+        self.picker.componentTwo = .Year
+        self.picker.componentThree = .Hour
         self.picker.setup()
         formatter.unitsStyle = .Abbreviated
     }
     
     @IBAction func updateLabel(sender: LETimeIntervalPicker) {
         label.text = formatter.stringFromTimeInterval(sender.timeInterval)
-        
-//        label.text = "\(sender.timeIntervalAsComponentTypes.valueOne) \(sender.timeIntervalAsComponentTypes.valueTwo) \(sender.timeIntervalAsComponentTypes.valueThree)"
+
     }
     
     @IBAction func setRandomTimeInterval() {
         let random = NSTimeInterval(arc4random_uniform(60*60*24)) // Random time under 24 hours
         if animated.on {
             picker.setTimeIntervalAnimated(random)
+
         } else {
             picker.timeInterval = random
         }

--- a/Example/LETimeIntervalPicker/ViewController.swift
+++ b/Example/LETimeIntervalPicker/ViewController.swift
@@ -19,8 +19,8 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.picker.componentOne = Components.Year
-        self.picker.componentTwo = .None
+        self.picker.componentOne = .Year
+        self.picker.componentTwo = .Second
         self.picker.componentThree = .None
         self.picker.setup()
         formatter.unitsStyle = .Abbreviated

--- a/Example/LETimeIntervalPicker/ViewController.swift
+++ b/Example/LETimeIntervalPicker/ViewController.swift
@@ -19,11 +19,17 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.picker.componentOne = Components.Year
+        self.picker.componentTwo = .Month
+        self.picker.componentThree = .Week
+        self.picker.setup()
         formatter.unitsStyle = .Abbreviated
     }
     
     @IBAction func updateLabel(sender: LETimeIntervalPicker) {
         label.text = formatter.stringFromTimeInterval(sender.timeInterval)
+        
+//        label.text = "\(sender.timeIntervalAsHoursMinutesSeconds.hours) \(sender.timeIntervalAsHoursMinutesSeconds.minutes) \(sender.timeIntervalAsHoursMinutesSeconds.seconds)"
     }
     
     @IBAction func setRandomTimeInterval() {

--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -26,34 +26,35 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     // MARK: - Public API
     
     
-    
-    //TODO: Need year/month/week/day timeInterval variable for storing/displaying the selected values.
-    
-    
     public var timeInterval: NSTimeInterval {
         get {
             
-            if let numOfComponents = self.componentsArray?.count {
+            if let safeComponentsArray = self.componentsArray {
                 
-                switch numOfComponents {
+                var numberOne = 0
+                var numberTwo = 0
+                var numberThree = 0
+                
+                switch safeComponentsArray.count {
                     
                 case 1:
                     
-                    let hours = pickerView.selectedRowInComponent(0) * 60 * 60
-                    return NSTimeInterval(hours)
+                    numberOne = self.convertComponentsDurationToSeconds(0)
+                    return NSTimeInterval(numberOne)
                     
                 case 2:
                     
-                    let hours = pickerView.selectedRowInComponent(0) * 60 * 60
-                    let minutes = pickerView.selectedRowInComponent(1) * 60
-                    return NSTimeInterval(hours + minutes)
+                    numberOne = self.convertComponentsDurationToSeconds(0)
+                    numberTwo = self.convertComponentsDurationToSeconds(1)
+                    numberThree = self.convertComponentsDurationToSeconds(2)
+                    return NSTimeInterval(numberOne + numberTwo)
                     
                 case 3:
                     
-                    let hours = pickerView.selectedRowInComponent(0) * 60 * 60
-                    let minutes = pickerView.selectedRowInComponent(1) * 60
-                    let seconds = pickerView.selectedRowInComponent(2)
-                    return NSTimeInterval(hours + minutes + seconds)
+                    numberOne = self.convertComponentsDurationToSeconds(0)
+                    numberTwo = self.convertComponentsDurationToSeconds(1)
+                    numberThree = self.convertComponentsDurationToSeconds(2)
+                    return NSTimeInterval(numberOne + numberTwo + numberThree)
                     
                     
                 default:
@@ -556,6 +557,30 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
             return dayString
         case .None:
             return ""
+        }
+        
+    }
+    
+    private func convertComponentsDurationToSeconds(componentsPosition: Int) -> Int {
+        
+        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentsPosition))! {
+            // Convert everything to seconds.
+        case .Hour:
+            return (self.pickerView.selectedRowInComponent(componentsPosition) * 60 * 60)
+        case .Minute:
+            return (self.pickerView.selectedRowInComponent(componentsPosition) * 60)
+        case .Second:
+            return (self.pickerView.selectedRowInComponent(componentsPosition) * 60 * 60)
+        case .Year:
+            return (self.pickerView.selectedRowInComponent(componentsPosition) * 365 * 24 * 60 * 60)
+        case .Month:
+            return (self.pickerView.selectedRowInComponent(componentsPosition) * 30 * 24 * 60 * 60)
+        case .Week:
+            return (self.pickerView.selectedRowInComponent(componentsPosition) * 7 * 24 * 60 * 60)
+        case .Day:
+            return (self.pickerView.selectedRowInComponent(componentsPosition) * 24 * 60 * 60)
+        default:
+            return 0
         }
         
     }

--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -570,7 +570,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         case .Minute:
             return (self.pickerView.selectedRowInComponent(componentsPosition) * 60)
         case .Second:
-            return (self.pickerView.selectedRowInComponent(componentsPosition) * 60 * 60)
+            return (self.pickerView.selectedRowInComponent(componentsPosition))
         case .Year:
             return (self.pickerView.selectedRowInComponent(componentsPosition) * 365 * 24 * 60 * 60)
         case .Month:

--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -21,7 +21,6 @@ public enum Components: Int {
     case Day
 }
 
-
 public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerViewDelegate {
     
     // MARK: - Public API
@@ -68,18 +67,22 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         get {
             return self.getTimeIntervalAsComponentTypes()
         }
+        
+        set {
+            self.setPickerComponentsToValues(newValue.valueOne.toInt()!, componentTwoValue: newValue.valueTwo.toInt()!, componentThreeValue: newValue.valueThree.toInt()!, animated: false)
+        }
     }
-    
-//    public var timeIntervalAsHoursMinutesSeconds: (hours: Int, minutes: Int, seconds: Int) {
-//        get {
-//            return secondsToHoursMinutesSeconds(Int(timeInterval))
-//        }
-//    }
     
     //TODO: Have a more general 'setPickerToTimeInterval()'
     
     public func setTimeIntervalAnimated(interval: NSTimeInterval) {
         setPickerToTimeInterval(interval, animated: true)
+    }
+    
+    public func setPickerComponentsToValuesAnimated(componentOneValue: String, componentTwoValue: String,
+        componentThreeValue: String) {
+            
+            self.setPickerComponentsToValues(componentOneValue.toInt()!, componentTwoValue: componentTwoValue.toInt()!, componentThreeValue: componentThreeValue.toInt()!, animated: true)
     }
     
     // Note that setting a font that makes the picker wider
@@ -335,7 +338,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
             break
             
         default:
-            println("Unhandled numberOfComponents (\(self.numberOfComponents)) in layoutSubviews()")
+            println("Unhandled numberOfComponents (\(self.numberOfComponents)) in 'layoutSubviews()'")
             break
         }
     }
@@ -585,13 +588,58 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     }
     
     private func setPickerToTimeInterval(interval: NSTimeInterval, animated: Bool) {
+        
         let time = secondsToHoursMinutesSeconds(Int(interval))
-        pickerView.selectRow(time.hours, inComponent: 0, animated: animated)
-        pickerView.selectRow(time.minutes, inComponent: 1, animated: animated)
-        pickerView.selectRow(time.seconds, inComponent: 2, animated: animated)
-        self.pickerView(pickerView, didSelectRow: time.hours, inComponent: 0)
-        self.pickerView(pickerView, didSelectRow: time.minutes, inComponent: 1)
-        self.pickerView(pickerView, didSelectRow: time.seconds, inComponent: 2)
+
+        switch self.numberOfComponents {
+        case 1:
+            pickerView.selectRow(time.hours, inComponent: 0, animated: animated)
+            self.pickerView(pickerView, didSelectRow: time.hours, inComponent: 0)
+            break
+        case 2:
+            pickerView.selectRow(time.hours, inComponent: 0, animated: animated)
+            pickerView.selectRow(time.minutes, inComponent: 1, animated: animated)
+            self.pickerView(pickerView, didSelectRow: time.hours, inComponent: 0)
+            self.pickerView(pickerView, didSelectRow: time.minutes, inComponent: 1)
+            break
+        case 3:
+            pickerView.selectRow(time.hours, inComponent: 0, animated: animated)
+            pickerView.selectRow(time.minutes, inComponent: 1, animated: animated)
+            pickerView.selectRow(time.seconds, inComponent: 2, animated: animated)
+            self.pickerView(pickerView, didSelectRow: time.hours, inComponent: 0)
+            self.pickerView(pickerView, didSelectRow: time.minutes, inComponent: 1)
+            self.pickerView(pickerView, didSelectRow: time.seconds, inComponent: 2)
+            break
+        default:
+            break
+        }
+    }
+    
+    private func setPickerComponentsToValues(componentOneValue: Int, componentTwoValue: Int,
+        componentThreeValue: Int, animated: Bool) {
+        
+            switch self.numberOfComponents {
+            case 1:
+                pickerView.selectRow(componentOneValue, inComponent: 0, animated: animated)
+                self.pickerView(pickerView, didSelectRow: componentOneValue, inComponent: 0)
+                break
+            case 2:
+                pickerView.selectRow(componentOneValue, inComponent: 0, animated: animated)
+                pickerView.selectRow(componentTwoValue, inComponent: 1, animated: animated)
+                self.pickerView(pickerView, didSelectRow: componentOneValue, inComponent: 0)
+                self.pickerView(pickerView, didSelectRow: componentTwoValue, inComponent: 1)
+                break
+            case 3:
+                pickerView.selectRow(componentOneValue, inComponent: 0, animated: animated)
+                pickerView.selectRow(componentTwoValue, inComponent: 1, animated: animated)
+                pickerView.selectRow(componentThreeValue, inComponent: 2, animated: animated)
+                self.pickerView(pickerView, didSelectRow: componentOneValue, inComponent: 0)
+                self.pickerView(pickerView, didSelectRow: componentTwoValue, inComponent: 1)
+                self.pickerView(pickerView, didSelectRow: componentThreeValue, inComponent: 2)
+                break
+            default:
+                break
+            }
     }
     
     private func secondsToHoursMinutesSeconds(seconds : Int) -> (hours: Int, minutes: Int, seconds: Int) {

--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -10,15 +10,103 @@ import UIKit
 
 // MARK: - Public Components Enum
 
-public enum Components: Int {
-    case None = -1
-    case Hour
-    case Minute
-    case Second
-    case Year
-    case Month
-    case Week
-    case Day
+/**
+Use the `Components` enum to specify the type of time-interval/duration that you'd like the row to display. 
+
+Usage:
+
+    //specifies that componentOne will be in years with 20 rows.
+    self.picker.componentOne = .Year(20)
+    //specifies that componentTwo will be in hours with 13 rows.
+    self.picker.componentTwo = .Hours(13)
+    //specifies that componentThree will be in minutes and will use the default value (60 rows)
+    self.picker.componentThree = .Minutes(nil)
+    //makes it so there will be no componentThree
+    self.picker.componentThree = .None
+
+The supported time-interval/duration types are:
+
+- .Hour
+- .Minute
+- .Second
+- .Year
+- .Month
+- .Week
+- .Day
+- .None (makes it so no component)
+*/
+public enum Components: Hashable {
+    ///Use to specify no component.
+    case None
+    ///Set the argument to `nil` to use the default value of 24 rows
+    case Hour(Int?)
+    ///Set the argument to `nil` to use the default value of 60 rows
+    case Minute(Int?)
+    ///Set the argument to `nil` to use the default value of 60 rows
+    case Second(Int?)
+    ///Set the argument to `nil` to use the default value of 100 rows
+    case Year(Int?)
+    ///Set the argument to `nil` to use the default value of 12 rows
+    case Month(Int?)
+    ///Set the argument to `nil` to use the default value of 52 rows
+    case Week(Int?)
+    ///Set the argument to `nil` to use the default value of 7 rows
+    case Day(Int?)
+    
+    
+    public var hashValue : Int {
+        return self.toInt()
+    }
+    
+    ///The default row count for the Component, if there wasn't one specified.
+    public var defaultRowCount : Int {
+        switch self {
+        case .Hour(nil):
+            return 24
+        case .Minute(nil):
+            return 60
+        case .Second(nil):
+            return 60
+        case .Year(nil):
+            return 100
+        case .Month(nil):
+            return 12
+        case .Week(nil):
+            return 52
+        case .Day(nil):
+            return 7
+        default:
+            return -1
+        }
+    }
+    
+    private func toInt() -> Int {
+        switch self {
+        case .None:
+            return -1
+        case .Hour:
+            return 0
+        case .Minute:
+            return 1
+        case .Second:
+            return 2
+        case .Year:
+            return 3
+        case .Month:
+            return 4
+        case .Week:
+            return 5
+        case .Day:
+            return 6
+        }
+        
+    }
+    
+}
+
+/// Overide equality operator so Components Enum conforms to Hashable
+public func == (lhs: Components, rhs: Components) -> Bool {
+    return lhs.toInt() == rhs.toInt()
 }
 
 public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerViewDelegate {
@@ -115,18 +203,18 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     // MARK: - Initialization
     
     required public init(coder aDecoder: NSCoder) {
-        self.componentOne = .Hour
-        self.componentTwo = .Minute
-        self.componentThree = .Second
+        self.componentOne = .Hour(24)
+        self.componentTwo = .Minute(60)
+        self.componentThree = .Second(60)
         super.init(coder: aDecoder)
         setup()
         
     }
     
     override public init(frame: CGRect) {
-        self.componentOne = .Hour
-        self.componentTwo = .Minute
-        self.componentThree = .Second
+        self.componentOne = .Hour(24)
+        self.componentTwo = .Minute(60)
+        self.componentThree = .Second(60)
         super.init(frame: frame)
         setup()
     }
@@ -352,23 +440,26 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     }
     
     public func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(component))! {
-        case .Hour:
-            return 24
-        case .Minute:
-            return 60
-        case .Second:
-            return 60
-        case .Year:
-            return 100
-        case .Month:
-            return 12
-        case .Week:
-            return 52
-        case .Day:
-            return 7
+        
+        let comp = self.getComponentForPickerComponentPosition(component)
+        
+        switch comp {
+        case let .Hour(numberOfRows) where numberOfRows != nil:
+            return numberOfRows!
+        case let .Minute(numberOfRows) where numberOfRows != nil:
+            return numberOfRows!
+        case let .Second(numberOfRows) where numberOfRows != nil:
+            return numberOfRows!
+        case let .Year(numberOfRows) where numberOfRows != nil:
+            return numberOfRows!
+        case let .Month(numberOfRows) where numberOfRows != nil:
+            return numberOfRows!
+        case let .Week(numberOfRows) where numberOfRows != nil:
+            return numberOfRows!
+        case let .Day(numberOfRows) where numberOfRows != nil:
+            return numberOfRows!
         default:
-            return -1
+            return comp.defaultRowCount
         }
     }
     
@@ -466,17 +557,17 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         }
     }
     
-    private func getComponentTypeForPickerComponentPosition(componentPostiion: Int) -> Int {
+    private func getComponentForPickerComponentPosition(componentPostiion: Int) -> Components {
         
         switch (componentPostiion) {
         case 0:
-            return self.componentsArray![0].rawValue
+            return self.componentsArray![0]
         case 1:
-            return self.componentsArray![1].rawValue
+            return self.componentsArray![1]
         case 2:
-            return self.componentsArray![2].rawValue
+            return self.componentsArray![2]
         default:
-            return -1
+            return .None
         }
         
     }
@@ -500,7 +591,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     private func getPluralTextForPickerComponentPosition(componentPosition: Int) -> String {
         
-        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentPosition))! {
+        switch self.getComponentForPickerComponentPosition(componentPosition) {
         case .Hour:
             return hoursString
         case .Minute:
@@ -523,7 +614,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     private func getSingularTextForPickerComponentPosition(componentPosition: Int) -> String {
         
-        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentPosition))! {
+        switch self.getComponentForPickerComponentPosition(componentPosition)  {
         case .Hour:
             return hourString
         case .Minute:
@@ -546,7 +637,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     private func convertComponentsDurationToSeconds(componentsPosition: Int) -> Int {
         
-        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentsPosition))! {
+        switch self.getComponentForPickerComponentPosition(componentsPosition)  {
             // Convert everything to seconds.
         case .Hour:
             return (self.pickerView.selectedRowInComponent(componentsPosition) * 60 * 60)
@@ -592,7 +683,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     private func setPickerToTimeInterval(interval: NSTimeInterval, animated: Bool) {
         
         let time = secondsToHoursMinutesSeconds(Int(interval))
-
+        
         switch self.numberOfComponents {
         case 1:
             pickerView.selectRow(time.hours, inComponent: 0, animated: animated)
@@ -619,7 +710,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     private func setPickerComponentsToValues(componentOneValue: Int?, componentTwoValue: Int?,
         componentThreeValue: Int?, animated: Bool) {
-        
+            
             
             switch self.numberOfComponents {
             case 1:
@@ -682,7 +773,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
             return ""
         }
         
-        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentPosition))! {
+        switch self.getComponentForPickerComponentPosition(componentPosition) {
         case .Hour:
             return "\(self.pickerView.selectedRowInComponent(componentPosition))h"
         case .Minute:

--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -28,30 +28,39 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     public var timeInterval: NSTimeInterval {
         get {
             
-            switch self.getNumberOfComponentsInPicker() {
-            case 1:
+            if let numOfComponents = self.componentsArray?.count {
                 
-                let hours = pickerView.selectedRowInComponent(0) * 60 * 60
-                return NSTimeInterval(hours)
+                switch numOfComponents {
+                    
+                case 1:
+                    
+                    let hours = pickerView.selectedRowInComponent(0) * 60 * 60
+                    return NSTimeInterval(hours)
+                    
+                case 2:
+                    
+                    let hours = pickerView.selectedRowInComponent(0) * 60 * 60
+                    let minutes = pickerView.selectedRowInComponent(1) * 60
+                    return NSTimeInterval(hours + minutes)
+                    
+                case 3:
+                    
+                    let hours = pickerView.selectedRowInComponent(0) * 60 * 60
+                    let minutes = pickerView.selectedRowInComponent(1) * 60
+                    let seconds = pickerView.selectedRowInComponent(2)
+                    return NSTimeInterval(hours + minutes + seconds)
+                    
+                    
+                default:
+                    return 0
+                }
                 
-            case 2:
+            } else {
                 
-                let hours = pickerView.selectedRowInComponent(0) * 60 * 60
-                let minutes = pickerView.selectedRowInComponent(1) * 60
-                return NSTimeInterval(hours + minutes)
-                
-            case 3:
-                
-                let hours = pickerView.selectedRowInComponent(0) * 60 * 60
-                let minutes = pickerView.selectedRowInComponent(1) * 60
-                let seconds = pickerView.selectedRowInComponent(2)
-                return NSTimeInterval(hours + minutes + seconds)
-                
-            
-            default:
                 return 0
             }
 
+            
         }
         set {
             setPickerToTimeInterval(newValue, animated: false)
@@ -91,6 +100,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     public var componentOne: Components
     public var componentTwo: Components
     public var componentThree: Components
+    private var componentsArray: [Components]?
     
     // MARK: - Initialization
     
@@ -142,6 +152,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     }
     
     public func setup() {
+        createValidComponentsArray()
         setupLocalizations()
         setupLabels()
         calculateNumberWidth()
@@ -151,13 +162,38 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     private func setupLabels() {
         
-        labelOne.text = getLabelTextForComponent(componentOne)
-        addSubview(labelOne)
-        labelTwo.text = getLabelTextForComponent(componentTwo)
-        addSubview(labelTwo)
-        labelThree.text = getLabelTextForComponent(componentThree)
-        addSubview(labelThree)
-        updateLabels()
+        if let safeComponents = self.componentsArray {
+            
+            switch safeComponents.count {
+                
+            case 1:
+                labelOne.text = getLabelTextForComponent(safeComponents[0])
+                addSubview(labelOne)
+                break
+                
+            case 2:
+                labelOne.text = getLabelTextForComponent(safeComponents[0])
+                addSubview(labelOne)
+                labelTwo.text = getLabelTextForComponent(safeComponents[1])
+                addSubview(labelTwo)
+                break
+                
+            case 3:
+                labelOne.text = getLabelTextForComponent(safeComponents[0])
+                addSubview(labelOne)
+                labelTwo.text = getLabelTextForComponent(safeComponents[1])
+                addSubview(labelTwo)
+                labelThree.text = getLabelTextForComponent(safeComponents[2])
+                addSubview(labelThree)
+                break
+                
+            default:
+                break
+            }
+
+            updateLabels()
+        }
+
     }
     
     private func getLabelTextForComponent(component: Components) -> String? {
@@ -274,101 +310,66 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         
         // Reposition labels
         
-        switch (self.getNumberOfComponentsInPicker()) {
-        case 1:
-            
-            labelOne.center = CGPoint(x: CGRectGetMidX(pickerView.frame) + (labelSpacing * 2),
-                                                    y: CGRectGetMidY(pickerView.frame))
-            
-            labelTwo.hidden = true
-            labelThree.hidden = true
-            
-            break
-            
-        case 2:
-            
-            labelOne.center.y = CGRectGetMidY(pickerView.frame)
-            labelTwo.center.y = CGRectGetMidY(pickerView.frame)
-            
-            let pickerMinX = CGRectGetMidX(bounds) - totalPickerWidth / 2
-            labelOne.frame.origin.x = pickerMinX + numberWidth + (labelSpacing * 5)
-            
-            let space = standardComponentSpacing + extraComponentSpacing + numberWidth + labelSpacing
-            labelTwo.frame.origin.x = CGRectGetMaxX(labelOne.frame) + space
-            
-            labelThree.hidden = true
+        if let numOfComponents = self.componentsArray?.count {
 
-            break
-            
-        case 3:
-            
-            labelOne.center.y = CGRectGetMidY(pickerView.frame)
-            labelTwo.center.y = CGRectGetMidY(pickerView.frame)
-            labelThree.center.y = CGRectGetMidY(pickerView.frame)
-            
-            let pickerMinX = CGRectGetMidX(bounds) - totalPickerWidth / 2
-            labelOne.frame.origin.x = pickerMinX + numberWidth + labelSpacing
-            let space = standardComponentSpacing + extraComponentSpacing + numberWidth + labelSpacing
-            labelTwo.frame.origin.x = CGRectGetMaxX(labelOne.frame) + space
-            labelThree.frame.origin.x = CGRectGetMaxX(labelTwo.frame) + space
-            
-            break
-            
-        default:
-            break
+            switch (numOfComponents) {
+            case 1:
+                
+                labelOne.center = CGPoint(x: CGRectGetMidX(pickerView.frame) + (labelSpacing * 2),
+                    y: CGRectGetMidY(pickerView.frame))
+                
+                labelTwo.hidden = true
+                labelThree.hidden = true
+                
+                break
+                
+            case 2:
+//                numberWidth + labelWidth + labelSpacing + extraComponentSpacing
+                
+                labelOne.center.y = CGRectGetMidY(pickerView.frame)
+                labelTwo.center.y = CGRectGetMidY(pickerView.frame)
+                
+                let pickerMinX = CGRectGetMidX(bounds) - totalPickerWidth / 2
+                labelOne.frame.origin.x = pickerMinX + (numberWidth * 3) + (labelSpacing * 2) + extraComponentSpacing
+                
+                let space = standardComponentSpacing + extraComponentSpacing + (labelSpacing * 5)
+                labelTwo.frame.origin.x = CGRectGetMaxX(labelOne.frame) + space
+                
+                labelThree.hidden = true
+                
+                break
+                
+            case 3:
+                
+                labelOne.center.y = CGRectGetMidY(pickerView.frame)
+                labelTwo.center.y = CGRectGetMidY(pickerView.frame)
+                labelThree.center.y = CGRectGetMidY(pickerView.frame)
+                
+                let pickerMinX = CGRectGetMidX(bounds) - totalPickerWidth / 2
+                labelOne.frame.origin.x = pickerMinX + numberWidth + labelSpacing
+                let space = standardComponentSpacing + extraComponentSpacing + numberWidth + labelSpacing
+                labelTwo.frame.origin.x = CGRectGetMaxX(labelOne.frame) + space
+                labelThree.frame.origin.x = CGRectGetMaxX(labelTwo.frame) + space
+                
+                break
+                
+            default:
+                break
+            }
         }
         
-
     }
     
     // MARK: - Picker view data source
     
     public func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
         
-        return self.getNumberOfComponentsInPicker()
-//        return 3
-        
-    }
-    
-    private func getNumberOfComponentsInPicker() -> Int {
-        
-        switch (self.componentOne, self.componentTwo, self.componentThree) {
-        case (_, .None, .None):
+        if let numOfComponents = self.componentsArray?.count {
             
-            return 1
-            
-        case (_, _, .None):
-            
-            return 2
-            
-        case (.None, _, .None):
-            
-            return 1
-            
-        case (.None, .None, _):
-            
-            return 1
-            
-        case (_, .None, _):
-            
-            return 2
-            
-        case (.None, _, _):
-            
-            return 2
-            
-        case (_, _, _):
-            
-            return 3
-            
-        case (.None, .None, .None):
-            
-            return 0
-            
-        default:
-            return 0
+            return numOfComponents
         }
-
+        
+        return 0
         
     }
     
@@ -396,6 +397,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     // MARK: - Picker view delegate
     
     public func pickerView(pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+        
         let labelWidth: CGFloat
         
         switch (component) {
@@ -406,7 +408,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         case 2:
             labelWidth = labelThree.bounds.width
         default:
-            labelWidth = 0.0
+            return 0.0
         }
         
         return numberWidth + labelWidth + labelSpacing + extraComponentSpacing
@@ -446,11 +448,11 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
             
             switch (component) {
             case 0:
-                labelOne.text = self.getComponentSingularTextForPickerComponentPosition(component)
+                labelOne.text = self.getSingularTextForPickerComponentPosition(component)
             case 1:
-                labelTwo.text = self.getComponentSingularTextForPickerComponentPosition(component)
+                labelTwo.text = self.getSingularTextForPickerComponentPosition(component)
             case 2:
-                labelThree.text = self.getComponentSingularTextForPickerComponentPosition(component)
+                labelThree.text = self.getSingularTextForPickerComponentPosition(component)
             default:
                 break
             }
@@ -460,11 +462,11 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
             
             switch (component) {
             case 0:
-                labelOne.text = self.getComponentPluralTextForPickerComponentPosition(component)
+                labelOne.text = self.getPluralTextForPickerComponentPosition(component)
             case 1:
-                labelTwo.text = self.getComponentPluralTextForPickerComponentPosition(component)
+                labelTwo.text = self.getPluralTextForPickerComponentPosition(component)
             case 2:
-                labelThree.text = self.getComponentPluralTextForPickerComponentPosition(component)
+                labelThree.text = self.getPluralTextForPickerComponentPosition(component)
             default:
                 break
             }
@@ -476,22 +478,40 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     // MARK: - Helpers
     
+    //TODO: Fix Break - gets wrong componentType because positions are up in the air.
     private func getComponentTypeForPickerComponentPosition(componentPostiion: Int) -> Int {
         
         switch (componentPostiion) {
         case 0:
-            return self.componentOne.rawValue
+            return self.componentsArray![0].rawValue
         case 1:
-            return self.componentTwo.rawValue
+            return self.componentsArray![1].rawValue
         case 2:
-            return self.componentThree.rawValue
+            return self.componentsArray![2].rawValue
         default:
             return -1
         }
         
     }
     
-    private func getComponentPluralTextForPickerComponentPosition(componentPosition: Int) -> String {
+    private func createValidComponentsArray() {
+        self.componentsArray = [Components]()
+        
+        if self.componentOne != .None {
+            self.componentsArray?.append(self.componentOne)
+        }
+        
+        if self.componentTwo != .None {
+            self.componentsArray?.append(self.componentTwo)
+        }
+        
+        if self.componentThree != .None {
+            self.componentsArray?.append(self.componentThree)
+        }
+
+    }
+    
+    private func getPluralTextForPickerComponentPosition(componentPosition: Int) -> String {
         
         switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentPosition))! {
         case .Hour:
@@ -514,7 +534,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         
     }
     
-    private func getComponentSingularTextForPickerComponentPosition(componentPosition: Int) -> String {
+    private func getSingularTextForPickerComponentPosition(componentPosition: Int) -> String {
         
         switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentPosition))! {
         case .Hour:

--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+// MARK: - Public Components Enum
 
 public enum Components: Int {
     case None = -1
@@ -28,56 +29,54 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     public var timeInterval: NSTimeInterval {
         get {
+            var numberOne = 0
+            var numberTwo = 0
+            var numberThree = 0
             
-            if let safeComponentsArray = self.componentsArray {
+            switch self.numberOfComponents {
                 
-                var numberOne = 0
-                var numberTwo = 0
-                var numberThree = 0
+            case 1:
                 
-                switch safeComponentsArray.count {
-                    
-                case 1:
-                    
-                    numberOne = self.convertComponentsDurationToSeconds(0)
-                    return NSTimeInterval(numberOne)
-                    
-                case 2:
-                    
-                    numberOne = self.convertComponentsDurationToSeconds(0)
-                    numberTwo = self.convertComponentsDurationToSeconds(1)
-                    numberThree = self.convertComponentsDurationToSeconds(2)
-                    return NSTimeInterval(numberOne + numberTwo)
-                    
-                case 3:
-                    
-                    numberOne = self.convertComponentsDurationToSeconds(0)
-                    numberTwo = self.convertComponentsDurationToSeconds(1)
-                    numberThree = self.convertComponentsDurationToSeconds(2)
-                    return NSTimeInterval(numberOne + numberTwo + numberThree)
-                    
-                    
-                default:
-                    return 0
-                }
+                numberOne = self.convertComponentsDurationToSeconds(0)
+                return NSTimeInterval(numberOne)
                 
-            } else {
+            case 2:
                 
+                numberOne = self.convertComponentsDurationToSeconds(0)
+                numberTwo = self.convertComponentsDurationToSeconds(1)
+                return NSTimeInterval(numberOne + numberTwo)
+                
+            case 3:
+                
+                numberOne = self.convertComponentsDurationToSeconds(0)
+                numberTwo = self.convertComponentsDurationToSeconds(1)
+                numberThree = self.convertComponentsDurationToSeconds(2)
+                return NSTimeInterval(numberOne + numberTwo + numberThree)
+                
+                
+            default:
                 return 0
             }
-
-            
         }
         set {
             setPickerToTimeInterval(newValue, animated: false)
         }
     }
     
-    public var timeIntervalAsHoursMinutesSeconds: (hours: Int, minutes: Int, seconds: Int) {
+    
+    public var timeIntervalAsComponentTypes: (valueOne: String, valueTwo: String, valueThree: String) {
         get {
-            return secondsToHoursMinutesSeconds(Int(timeInterval))
+            return self.getTimeIntervalAsComponentTypes()
         }
     }
+    
+//    public var timeIntervalAsHoursMinutesSeconds: (hours: Int, minutes: Int, seconds: Int) {
+//        get {
+//            return secondsToHoursMinutesSeconds(Int(timeInterval))
+//        }
+//    }
+    
+    //TODO: Have a more general 'setPickerToTimeInterval()'
     
     public func setTimeIntervalAnimated(interval: NSTimeInterval) {
         setPickerToTimeInterval(interval, animated: true)
@@ -196,31 +195,10 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
             default:
                 break
             }
-
+            
             updateLabels()
         }
-
-    }
-    
-    private func getLabelTextForComponent(component: Components) -> String? {
-        switch component {
-        case .Hour:
-            return hoursString
-        case .Minute:
-            return minutesString
-        case .Second:
-            return secondsString
-        case .Year:
-            return yearsString
-        case .Month:
-            return monthsString
-        case .Week:
-            return weeksString
-        case .Day:
-            return daysString
-        case .None:
-            return nil
-        }
+        
     }
     
     private func updateLabels() {
@@ -316,65 +294,56 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         
         // Reposition labels
         
-        if let numOfComponents = self.componentsArray?.count {
-
-            switch (numOfComponents) {
-            case 1:
-                
-                labelOne.center = CGPoint(x: CGRectGetMidX(pickerView.frame) + (labelSpacing * 2),
-                    y: CGRectGetMidY(pickerView.frame))
-                
-                labelTwo.hidden = true
-                labelThree.hidden = true
-                
-                break
-                
-            case 2:
-                
-                labelOne.center.y = CGRectGetMidY(pickerView.frame)
-                labelTwo.center.y = CGRectGetMidY(pickerView.frame)
-                
-                let pickerMinX = CGRectGetMidX(bounds) - totalPickerWidth / 2
-                labelOne.frame.origin.x = pickerMinX + (numberWidth * 3) + (labelSpacing * 2) + extraComponentSpacing
-                
-                let space = standardComponentSpacing + extraComponentSpacing + (labelSpacing * 5)
-                labelTwo.frame.origin.x = CGRectGetMaxX(labelOne.frame) + space
-                
-                labelThree.hidden = true
-                
-                break
-                
-            case 3:
-                
-                labelOne.center.y = CGRectGetMidY(pickerView.frame)
-                labelTwo.center.y = CGRectGetMidY(pickerView.frame)
-                labelThree.center.y = CGRectGetMidY(pickerView.frame)
-                
-                let pickerMinX = CGRectGetMidX(bounds) - totalPickerWidth / 2
-                labelOne.frame.origin.x = pickerMinX + numberWidth + labelSpacing
-                let space = standardComponentSpacing + extraComponentSpacing + numberWidth + labelSpacing
-                labelTwo.frame.origin.x = CGRectGetMaxX(labelOne.frame) + space
-                labelThree.frame.origin.x = CGRectGetMaxX(labelTwo.frame) + space
-                
-                break
-                
-            default:
-                break
-            }
+        switch (self.numberOfComponents) {
+        case 1:
+            
+            labelOne.center = CGPoint(x: CGRectGetMidX(pickerView.frame) + (labelSpacing * 2),
+                y: CGRectGetMidY(pickerView.frame))
+            
+            labelTwo.hidden = true
+            labelThree.hidden = true
+            
+            break
+            
+        case 2:
+            
+            labelOne.center.y = CGRectGetMidY(pickerView.frame)
+            labelTwo.center.y = CGRectGetMidY(pickerView.frame)
+            
+            let pickerMinX = CGRectGetMidX(bounds) - totalPickerWidth / 2
+            labelOne.frame.origin.x = pickerMinX + (numberWidth * 3) + (labelSpacing * 2) + extraComponentSpacing
+            
+            let space = standardComponentSpacing + extraComponentSpacing + (labelSpacing * 5)
+            labelTwo.frame.origin.x = CGRectGetMaxX(labelOne.frame) + space
+            
+            labelThree.hidden = true
+            
+            break
+            
+        case 3:
+            
+            labelOne.center.y = CGRectGetMidY(pickerView.frame)
+            labelTwo.center.y = CGRectGetMidY(pickerView.frame)
+            labelThree.center.y = CGRectGetMidY(pickerView.frame)
+            
+            let pickerMinX = CGRectGetMidX(bounds) - totalPickerWidth / 2
+            labelOne.frame.origin.x = pickerMinX + numberWidth + labelSpacing
+            let space = standardComponentSpacing + extraComponentSpacing + numberWidth + labelSpacing
+            labelTwo.frame.origin.x = CGRectGetMaxX(labelOne.frame) + space
+            labelThree.frame.origin.x = CGRectGetMaxX(labelTwo.frame) + space
+            
+            break
+            
+        default:
+            println("Unhandled numberOfComponents (\(self.numberOfComponents)) in layoutSubviews()")
+            break
         }
-        
     }
     
     // MARK: - Picker view data source
     
     public func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
-        
-        if let numOfComponents = self.componentsArray?.count {
-            return numOfComponents
-        }
-        
-        return 0
-        
+        return self.numberOfComponents
     }
     
     public func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
@@ -392,7 +361,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         case .Week:
             return 52
         case .Day:
-            return 365
+            return 7
         default:
             return -1
         }
@@ -483,6 +452,15 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     // MARK: - Helpers
     
+    private var numberOfComponents: Int {
+        get {
+            if let safeCount = self.componentsArray?.count {
+                return safeCount
+            }
+            return 0
+        }
+    }
+    
     private func getComponentTypeForPickerComponentPosition(componentPostiion: Int) -> Int {
         
         switch (componentPostiion) {
@@ -512,7 +490,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         if self.componentThree != .None {
             self.componentsArray?.append(self.componentThree)
         }
-
+        
     }
     
     private func getPluralTextForPickerComponentPosition(componentPosition: Int) -> String {
@@ -585,6 +563,27 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         
     }
     
+    private func getLabelTextForComponent(component: Components) -> String? {
+        switch component {
+        case .Hour:
+            return hoursString
+        case .Minute:
+            return minutesString
+        case .Second:
+            return secondsString
+        case .Year:
+            return yearsString
+        case .Month:
+            return monthsString
+        case .Week:
+            return weeksString
+        case .Day:
+            return daysString
+        case .None:
+            return nil
+        }
+    }
+    
     private func setPickerToTimeInterval(interval: NSTimeInterval, animated: Bool) {
         let time = secondsToHoursMinutesSeconds(Int(interval))
         pickerView.selectRow(time.hours, inComponent: 0, animated: animated)
@@ -597,6 +596,60 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     private func secondsToHoursMinutesSeconds(seconds : Int) -> (hours: Int, minutes: Int, seconds: Int) {
         return (seconds / 3600, (seconds % 3600) / 60, (seconds % 3600) % 60)
+    }
+    
+    private func getTimeIntervalAsComponentTypes() ->
+        (valueOne: String, valueTwo: String, valueThree: String) {
+            
+            var numberOne: String!
+            var numberTwo: String!
+            var numberThree: String!
+            
+            switch self.numberOfComponents {
+                
+            case 1:
+                numberOne = self.getFormattedComponentValue(0)
+                return (valueOne: numberOne, valueTwo: "", valueThree: "")
+            case 2:
+                numberOne = self.getFormattedComponentValue(0)
+                numberTwo = self.getFormattedComponentValue(1)
+                return (valueOne: numberOne, valueTwo: numberTwo, valueThree: "")
+            case 3:
+                numberOne = self.getFormattedComponentValue(0)
+                numberTwo = self.getFormattedComponentValue(1)
+                numberThree = self.getFormattedComponentValue(2)
+                return (valueOne: numberOne, valueTwo: numberTwo, valueThree: numberThree)
+            default:
+                return ("","","")
+            }
+            
+            
+    }
+    
+    private func getFormattedComponentValue(componentPosition: Int) -> String {
+        
+        if self.pickerView.selectedRowInComponent(componentPosition) == 0 {
+            return ""
+        }
+        
+        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentPosition))! {
+        case .Hour:
+            return "\(self.pickerView.selectedRowInComponent(componentPosition))h"
+        case .Minute:
+            return "\(self.pickerView.selectedRowInComponent(componentPosition))m"
+        case .Second:
+            return "\(self.pickerView.selectedRowInComponent(componentPosition))s"
+        case .Year:
+            return "\(self.pickerView.selectedRowInComponent(componentPosition))y"
+        case .Month:
+            return "\(self.pickerView.selectedRowInComponent(componentPosition))m"
+        case .Week:
+            return "\(self.pickerView.selectedRowInComponent(componentPosition))w"
+        case .Day:
+            return "\(self.pickerView.selectedRowInComponent(componentPosition))d"
+        default:
+            return ""
+        }
     }
     
     // MARK: - Localization

--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -11,7 +11,7 @@ import UIKit
 
 public enum Components: Int {
     case None = -1
-    case Hour = 0
+    case Hour
     case Minute
     case Second
     case Year
@@ -24,6 +24,11 @@ public enum Components: Int {
 public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerViewDelegate {
     
     // MARK: - Public API
+    
+    
+    
+    //TODO: Need year/month/week/day timeInterval variable for storing/displaying the selected values.
+    
     
     public var timeInterval: NSTimeInterval {
         get {
@@ -97,9 +102,9 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     private let labelThree = UILabel()
     
     // Component type for each picker column (defaults to hour, minute, second)
-    public var componentOne: Components
-    public var componentTwo: Components
-    public var componentThree: Components
+    public var componentOne: Components = .None
+    public var componentTwo: Components = .None
+    public var componentThree: Components = .None
     private var componentsArray: [Components]?
     
     // MARK: - Initialization
@@ -324,7 +329,6 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
                 break
                 
             case 2:
-//                numberWidth + labelWidth + labelSpacing + extraComponentSpacing
                 
                 labelOne.center.y = CGRectGetMidY(pickerView.frame)
                 labelTwo.center.y = CGRectGetMidY(pickerView.frame)
@@ -365,7 +369,6 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     public func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
         
         if let numOfComponents = self.componentsArray?.count {
-            
             return numOfComponents
         }
         
@@ -443,6 +446,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     }
     
     public func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        
         if row == 1 {
             // Change label to singular
             
@@ -478,7 +482,6 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     // MARK: - Helpers
     
-    //TODO: Fix Break - gets wrong componentType because positions are up in the air.
     private func getComponentTypeForPickerComponentPosition(componentPostiion: Int) -> Int {
         
         switch (componentPostiion) {

--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -79,10 +79,12 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         setPickerToTimeInterval(interval, animated: true)
     }
     
-    public func setPickerComponentsToValuesAnimated(componentOneValue: String, componentTwoValue: String,
-        componentThreeValue: String) {
+    public func setPickerComponentsToValuesAnimated(componentOneValue: String?, componentTwoValue: String?,
+        componentThreeValue: String?) {
             
-            self.setPickerComponentsToValues(componentOneValue.toInt()!, componentTwoValue: componentTwoValue.toInt()!, componentThreeValue: componentThreeValue.toInt()!, animated: true)
+            
+            
+            self.setPickerComponentsToValues(componentOneValue?.toInt(), componentTwoValue: componentTwoValue?.toInt(), componentThreeValue: componentThreeValue?.toInt(), animated: true)
     }
     
     // Note that setting a font that makes the picker wider
@@ -615,27 +617,27 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         }
     }
     
-    private func setPickerComponentsToValues(componentOneValue: Int, componentTwoValue: Int,
-        componentThreeValue: Int, animated: Bool) {
+    private func setPickerComponentsToValues(componentOneValue: Int?, componentTwoValue: Int?,
+        componentThreeValue: Int?, animated: Bool) {
         
+            
             switch self.numberOfComponents {
             case 1:
-                pickerView.selectRow(componentOneValue, inComponent: 0, animated: animated)
-                self.pickerView(pickerView, didSelectRow: componentOneValue, inComponent: 0)
+                pickerView.selectRow(componentOneValue!, inComponent: 0, animated: animated)
+                self.pickerView(pickerView, didSelectRow: componentOneValue!, inComponent: 0)
                 break
             case 2:
-                pickerView.selectRow(componentOneValue, inComponent: 0, animated: animated)
-                pickerView.selectRow(componentTwoValue, inComponent: 1, animated: animated)
-                self.pickerView(pickerView, didSelectRow: componentOneValue, inComponent: 0)
-                self.pickerView(pickerView, didSelectRow: componentTwoValue, inComponent: 1)
+                pickerView.selectRow(componentOneValue!, inComponent: 0, animated: animated)
+                pickerView.selectRow(componentTwoValue!, inComponent: 1, animated: animated)
+                self.pickerView(pickerView, didSelectRow: componentOneValue!, inComponent: 1)
                 break
             case 3:
-                pickerView.selectRow(componentOneValue, inComponent: 0, animated: animated)
-                pickerView.selectRow(componentTwoValue, inComponent: 1, animated: animated)
-                pickerView.selectRow(componentThreeValue, inComponent: 2, animated: animated)
-                self.pickerView(pickerView, didSelectRow: componentOneValue, inComponent: 0)
-                self.pickerView(pickerView, didSelectRow: componentTwoValue, inComponent: 1)
-                self.pickerView(pickerView, didSelectRow: componentThreeValue, inComponent: 2)
+                pickerView.selectRow(componentOneValue!, inComponent: 0, animated: animated)
+                pickerView.selectRow(componentTwoValue!, inComponent: 1, animated: animated)
+                pickerView.selectRow(componentThreeValue!, inComponent: 2, animated: animated)
+                self.pickerView(pickerView, didSelectRow: componentOneValue!, inComponent: 0)
+                self.pickerView(pickerView, didSelectRow: componentTwoValue!, inComponent: 1)
+                self.pickerView(pickerView, didSelectRow: componentThreeValue!, inComponent: 2)
                 break
             default:
                 break

--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -8,6 +8,17 @@
 
 import UIKit
 
+
+public enum Components: Int {
+    case Hour = 0
+    case Minute
+    case Second
+    case Year
+    case Month
+    case Week
+    case Day
+}
+
 public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerViewDelegate {
     
     // MARK: - Public API
@@ -29,7 +40,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
             return secondsToHoursMinutesSeconds(Int(timeInterval))
         }
     }
-
+    
     public func setTimeIntervalAnimated(interval: NSTimeInterval) {
         setPickerToTimeInterval(interval, animated: true)
     }
@@ -49,15 +60,21 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     private let pickerView = UIPickerView()
     
-    private let hourLabel = UILabel()
-    private let minuteLabel = UILabel()
-    private let secondLabel = UILabel()
+    private let labelOne = UILabel()
+    private let labelTwo = UILabel()
+    private let labelThree = UILabel()
+    
+    // Component type for each picker column (defaults to hour, minute, second)
+    public var componentOne: Components = .Hour
+    public var componentTwo: Components = .Minute
+    public var componentThree: Components = .Second
     
     // MARK: - Initialization
     
     required public init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setup()
+        
     }
     
     override public init(frame: CGRect) {
@@ -65,7 +82,34 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         setup()
     }
     
-    private func setup() {
+    convenience public init(componentOne: Components) {
+        
+        self.init()
+        self.componentOne = componentOne
+        setup()
+    }
+    
+    convenience public init(componentOne: Components, componentTwo: Components) {
+        
+        self.init()
+        self.componentOne = componentOne
+        self.componentTwo = componentTwo
+        setup()
+    }
+    
+    //Use this init() to define a custom component type for each picker column
+    
+    convenience public init(componentOne: Components, componentTwo: Components,
+        componentThree: Components) {
+            
+            self.init()
+            self.componentOne = componentOne
+            self.componentTwo = componentTwo
+            self.componentThree = componentThree
+            setup()
+    }
+    
+    public func setup() {
         setupLocalizations()
         setupLabels()
         calculateNumberWidth()
@@ -74,22 +118,42 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     }
     
     private func setupLabels() {
-        hourLabel.text = hoursString
-        addSubview(hourLabel)
-        minuteLabel.text = minutesString
-        addSubview(minuteLabel)
-        secondLabel.text = secondsString
-        addSubview(secondLabel)
+        
+        labelOne.text = getLabelTextForComponent(componentOne)
+        addSubview(labelOne)
+        labelTwo.text = getLabelTextForComponent(componentTwo)
+        addSubview(labelTwo)
+        labelThree.text = getLabelTextForComponent(componentThree)
+        addSubview(labelThree)
         updateLabels()
     }
     
+    private func getLabelTextForComponent(component: Components) -> String {
+        switch component {
+        case .Hour:
+            return hoursString
+        case .Minute:
+            return minutesString
+        case .Second:
+            return secondsString
+        case .Year:
+            return yearsString
+        case .Month:
+            return monthsString
+        case .Week:
+            return weeksString
+        case .Day:
+            return daysString
+        }
+    }
+    
     private func updateLabels() {
-        hourLabel.font = font
-        hourLabel.sizeToFit()
-        minuteLabel.font = font
-        minuteLabel.sizeToFit()
-        secondLabel.font = font
-        secondLabel.sizeToFit()
+        labelOne.font = font
+        labelOne.sizeToFit()
+        labelTwo.font = font
+        labelTwo.sizeToFit()
+        labelThree.font = font
+        labelThree.sizeToFit()
     }
     
     private func calculateNumberWidth() {
@@ -107,11 +171,11 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     func calculateTotalPickerWidth() {
         // Used to position labels
-
+        
         totalPickerWidth = 0
-        totalPickerWidth += hourLabel.bounds.width
-        totalPickerWidth += minuteLabel.bounds.width
-        totalPickerWidth += secondLabel.bounds.width
+        totalPickerWidth += labelOne.bounds.width
+        totalPickerWidth += labelTwo.bounds.width
+        totalPickerWidth += labelThree.bounds.width
         totalPickerWidth += standardComponentSpacing * 2
         totalPickerWidth += extraComponentSpacing * 3
         totalPickerWidth += labelSpacing * 3
@@ -162,9 +226,10 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     // MARK: - Layout
     
+    
     private var totalPickerWidth: CGFloat = 0
     private var numberWidth: CGFloat = 20               // Width of UILabel displaying a two digit number with standard font
-
+    
     private let standardComponentSpacing: CGFloat = 5   // A UIPickerView has a 5 point space between components
     private let extraComponentSpacing: CGFloat = 10     // Add an additional 10 points between the components
     private let labelSpacing: CGFloat = 5               // Spacing between picker numbers and labels
@@ -174,15 +239,15 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         
         // Reposition labels
         
-        hourLabel.center.y = CGRectGetMidY(pickerView.frame)
-        minuteLabel.center.y = CGRectGetMidY(pickerView.frame)
-        secondLabel.center.y = CGRectGetMidY(pickerView.frame)
+        labelOne.center.y = CGRectGetMidY(pickerView.frame)
+        labelTwo.center.y = CGRectGetMidY(pickerView.frame)
+        labelThree.center.y = CGRectGetMidY(pickerView.frame)
         
         let pickerMinX = CGRectGetMidX(bounds) - totalPickerWidth / 2
-        hourLabel.frame.origin.x = pickerMinX + numberWidth + labelSpacing
+        labelOne.frame.origin.x = pickerMinX + numberWidth + labelSpacing
         let space = standardComponentSpacing + extraComponentSpacing + numberWidth + labelSpacing
-        minuteLabel.frame.origin.x = CGRectGetMaxX(hourLabel.frame) + space
-        secondLabel.frame.origin.x = CGRectGetMaxX(minuteLabel.frame) + space
+        labelTwo.frame.origin.x = CGRectGetMaxX(labelOne.frame) + space
+        labelThree.frame.origin.x = CGRectGetMaxX(labelTwo.frame) + space
     }
     
     // MARK: - Picker view data source
@@ -192,13 +257,23 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     }
     
     public func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        switch Components(rawValue: component)! {
+        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(component))! {
         case .Hour:
             return 24
         case .Minute:
             return 60
         case .Second:
             return 60
+        case .Year:
+            return 100
+        case .Month:
+            return 12
+        case .Week:
+            return 52
+        case .Day:
+            return 365
+        default:
+            return -1
         }
     }
     
@@ -206,14 +281,18 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     public func pickerView(pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
         let labelWidth: CGFloat
-        switch Components(rawValue: component)! {
-        case .Hour:
-            labelWidth = hourLabel.bounds.width
-        case .Minute:
-            labelWidth = minuteLabel.bounds.width
-        case .Second:
-            labelWidth = secondLabel.bounds.width
+        
+        switch (component) {
+        case 0:
+            labelWidth = labelOne.bounds.width
+        case 1:
+            labelWidth = labelTwo.bounds.width
+        case 2:
+            labelWidth = labelThree.bounds.width
+        default:
+            labelWidth = 0.0
         }
+        
         return numberWidth + labelWidth + labelSpacing + extraComponentSpacing
     }
     
@@ -248,30 +327,95 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     public func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         if row == 1 {
             // Change label to singular
-            switch Components(rawValue: component)! {
-            case .Hour:
-                hourLabel.text = hourString
-            case .Minute:
-                minuteLabel.text = minuteString
-            case .Second:
-                secondLabel.text = secondString
+            
+            switch (component) {
+            case 0:
+                labelOne.text = self.getComponentSingularTextForPickerComponentPosition(component)
+            case 1:
+                labelTwo.text = self.getComponentSingularTextForPickerComponentPosition(component)
+            case 2:
+                labelThree.text = self.getComponentSingularTextForPickerComponentPosition(component)
+            default:
+                break
             }
+            
         } else {
             // Change label to plural
-            switch Components(rawValue: component)! {
-            case .Hour:
-                hourLabel.text = hoursString
-            case .Minute:
-                minuteLabel.text = minutesString
-            case .Second:
-                secondLabel.text = secondsString
+            
+            switch (component) {
+            case 0:
+                labelOne.text = self.getComponentPluralTextForPickerComponentPosition(component)
+            case 1:
+                labelTwo.text = self.getComponentPluralTextForPickerComponentPosition(component)
+            case 2:
+                labelThree.text = self.getComponentPluralTextForPickerComponentPosition(component)
+            default:
+                break
             }
+            
         }
         
         sendActionsForControlEvents(.ValueChanged)
     }
     
     // MARK: - Helpers
+    
+    private func getComponentTypeForPickerComponentPosition(componentPostiion: Int) -> Int {
+        
+        switch (componentPostiion) {
+        case 0:
+            return self.componentOne.rawValue
+        case 1:
+            return self.componentTwo.rawValue
+        case 2:
+            return self.componentThree.rawValue
+        default:
+            return -1
+        }
+        
+    }
+    
+    private func getComponentPluralTextForPickerComponentPosition(componentPosition: Int) -> String {
+        
+        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentPosition))! {
+        case .Hour:
+            return hoursString
+        case .Minute:
+            return minutesString
+        case .Second:
+            return secondsString
+        case .Year:
+            return yearsString
+        case .Month:
+            return monthsString
+        case .Week:
+            return weeksString
+        case .Day:
+            return daysString
+        }
+        
+    }
+    
+    private func getComponentSingularTextForPickerComponentPosition(componentPosition: Int) -> String {
+        
+        switch Components(rawValue: self.getComponentTypeForPickerComponentPosition(componentPosition))! {
+        case .Hour:
+            return hourString
+        case .Minute:
+            return minuteString
+        case .Second:
+            return secondString
+        case .Year:
+            return yearString
+        case .Month:
+            return monthString
+        case .Week:
+            return weekString
+        case .Day:
+            return dayString
+        }
+        
+    }
     
     private func setPickerToTimeInterval(interval: NSTimeInterval, animated: Bool) {
         let time = secondsToHoursMinutesSeconds(Int(interval))
@@ -287,12 +431,6 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         return (seconds / 3600, (seconds % 3600) / 60, (seconds % 3600) % 60)
     }
     
-    private enum Components: Int {
-        case Hour = 0
-        case Minute
-        case Second
-    }
-    
     // MARK: - Localization
     
     private var hoursString     = "hours"
@@ -301,6 +439,14 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     private var minuteString    = "minute"
     private var secondsString   = "seconds"
     private var secondString    = "second"
+    private var yearsString     = "years"
+    private var yearString      = "year"
+    private var monthsString    = "months"
+    private var monthString     = "month"
+    private var weeksString     = "weeks"
+    private var weekString      = "week"
+    private var daysString      = "days"
+    private var dayString       = "day"
     
     private func setupLocalizations() {
         
@@ -324,5 +470,29 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
         
         secondString = NSLocalizedString("second", tableName: tableName, bundle: bundle,
             comment: "A singular alternative for the seconds text.")
+        
+        yearsString = NSLocalizedString("years", tableName: tableName, bundle: bundle,
+            comment: "The text displayed next to the years component of the picker.")
+        
+        yearString = NSLocalizedString("year", tableName: tableName, bundle: bundle,
+            comment: "A singular alternative for the years text.")
+        
+        monthsString = NSLocalizedString("months", tableName: tableName, bundle: bundle,
+            comment: "The text displayed next to the months component of the picker.")
+        
+        monthString = NSLocalizedString("month", tableName: tableName, bundle: bundle,
+            comment: "A singular alternative for the months text.")
+        
+        weeksString = NSLocalizedString("weeks", tableName: tableName, bundle: bundle,
+            comment: "The text displayed next to the weeks component of the picker.")
+        
+        weekString = NSLocalizedString("week", tableName: tableName, bundle: bundle,
+            comment: "A singular alternative for the weeks text.")
+        
+        daysString = NSLocalizedString("days", tableName: tableName, bundle: bundle,
+            comment: "The text displayed next to the days component of the picker.")
+        
+        dayString = NSLocalizedString("day", tableName: tableName, bundle: bundle,
+            comment: "A singular alternative for the days text.")
     }
 }


### PR DESCRIPTION
This pull request contains code to make LETimeIntervalPicker more customizable and introduces four new component types (Year, Month, Week, Day). The picker now supports the use of only one component, or two components, or three components at a time.

LETimeIntervalPicker defaults to the components "Hour, Minute, Second". Convenience initializers have been added so one, two, or three, different component types can be used instead of the default. 

If using InterfaceBuilder/Storyboards to create your UI, and you don't want to use the default components, you will need to specify your desired components after initialization like so:

```
/*
This will create a picker with two components (Weeks and Days)
*/
self.picker.componentOne = .Week
self.picker.componentTwo = .Day
self.picker.componentThree = .None
```

Use the `Components.None` enum to specify that there will be no component.
