### PR TITLE
Update LETimeIntervalPicker to Swift 2.0

### DIFF
--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -202,7 +202,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     // MARK: - Initialization
     
-    required public init(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         self.componentOne = .Hour(24)
         self.componentTwo = .Minute(60)
         self.componentThree = .Second(60)
@@ -332,7 +332,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     func setupPickerView() {
         pickerView.dataSource = self
         pickerView.delegate = self
-        pickerView.setTranslatesAutoresizingMaskIntoConstraints(false)
+        pickerView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(pickerView)
         
         // Size picker view to fit self


### PR DESCRIPTION
I changed the following two lines in this commit to build properly with XCode Version 7.0.1 (7A1001) and Swift 2.0.
