### PR TITLE
Update LETimeIntervalPicker to Swift 2.0

### DIFF
--- a/Pod/Classes/LETimeIntervalPicker.swift
+++ b/Pod/Classes/LETimeIntervalPicker.swift
@@ -55,7 +55,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     
     // MARK: - Initialization
     
-    required public init(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setup()
     }
@@ -121,7 +121,7 @@ public class LETimeIntervalPicker: UIControl, UIPickerViewDataSource, UIPickerVi
     func setupPickerView() {
         pickerView.dataSource = self
         pickerView.delegate = self
-        pickerView.setTranslatesAutoresizingMaskIntoConstraints(false)
+        pickerView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(pickerView)
         
         // Size picker view to fit self


### PR DESCRIPTION
After installing the pod into Xcode 7, my project wouldn't build until I changed these two lines.
